### PR TITLE
feat: Enhance find command and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Gcal.db
 db/*
 !db/.gitkeep
 setting.json
+.env
+docs/

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -64,6 +64,7 @@ Description |
         return;
       }
       const updatedText = fs.readFileSync(tempFilePath, 'utf8');
+      // TODO: ここで description なら一行だけでなく，全行引っ張ってくるようにする
       const extractDetails = (text) => {
         const lines = text.split('\n');
         const details = {};
@@ -175,7 +176,7 @@ Description | ${description}
     }
 
     if (allDay) {
-      event ={
+      event = {
         summary: title,
         description: description,
         start: {

--- a/src/commands/find.js
+++ b/src/commands/find.js
@@ -1,14 +1,60 @@
 import blessed from 'blessed';
 import contrib from 'blessed-contrib';
 import { searchIndexOfToday, formatGroupedEvents } from '../ui/layout.js';
+import { isSameDate } from '../utils/dateUtils.js';
 
 export function findCommand(screen, events, allEvents, args, keypressListener) {
-  const [keyword] = args;
-  const filteredEvents = allEvents.filter(event => event.summary && event.summary.includes(keyword));
   const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
   const logTable = screen.children.find(child => child.options.label === 'Gcal.js Log');
+
+  let keywords = [];
+  let searchDate = null;
+  let searchMonth = null;
+
+  const dateRegex = /^(\d{4}-\d{2}-\d{2}|\d{2}-\d{2})$/;
+  const monthRegex = /^(\d{1,2})$/;
+
+  args.forEach(arg => {
+    if (dateRegex.test(arg)) {
+      searchDate = new Date(arg);
+      if (arg.length === 5) {
+        searchDate.setFullYear(new Date().getFullYear());
+      }
+    } else if (monthRegex.test(arg)) {
+      const month = parseInt(arg, 10);
+      if (month >= 1 && month <= 12) {
+        searchMonth = month;
+      }
+    } else {
+      keywords.push(arg);
+    }
+  });
+
+  let filteredEvents = allEvents;
+
+  if (keywords.length > 0) {
+    filteredEvents = filteredEvents.filter(event =>
+      keywords.every(keyword => event.summary && event.summary.includes(keyword))
+    );
+  }
+
+  if (searchDate) {
+    filteredEvents = filteredEvents.filter(event => {
+      const eventStartDate = new Date(event.start);
+      return isSameDate(eventStartDate, searchDate);
+    });
+  }
+
+  if (searchMonth) {
+    filteredEvents = filteredEvents.filter(event => {
+      const eventStartDate = new Date(event.start);
+      return eventStartDate.getMonth() + 1 === searchMonth;
+    });
+  }
+
   if (filteredEvents.length === 0) {
     logTable.log('No events found');
+    screen.render();
     return;
   } else {
     events.length = 0;
@@ -18,7 +64,7 @@ export function findCommand(screen, events, allEvents, args, keypressListener) {
     leftTable.select(searchIndexOfToday(events));
     leftTable.scrollTo(leftTable.selected + leftTable.height - 3);
     leftTable.off('keypress', keypressListener);
-    logTable.log('Filtered events by keyword: ' + keyword);
+    logTable.log(`Filtered events by: ${args.join(' ')}`);
     screen.render();
     return;
   }

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -61,3 +61,18 @@
     const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     return daysOfWeek[date.getDay()];
   }
+
+/**
+ * Check if two Date objects represent the same date (ignoring time).
+ *
+ * @param {Date} date1 - The first date.
+ * @param {Date} date2 - The second date.
+ * @returns {boolean} - True if the dates are the same, false otherwise.
+ */
+export function isSameDate(date1, date2) {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}


### PR DESCRIPTION
This commit enhances the `find` command to allow searching by date and month, in addition to keywords. It also includes a few other fixes and improvements.

- Enhanced `find` command:
  - Search by date in `YYYY-MM-DD` format
  - Search by date in `MM-DD` format
  - Search by month in `MM` or `M` format
  - Combined keyword and date/month AND search
- Added `isSameDate` function to `dateUtils.js`
- Added `docs/` and `.env` to `.gitignore`
- Minor fix in `add.js`
