### PR TITLE
Feat/add multi event window

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,22 @@
 </p>
 
 ## For Japanese
+
 [日本語版README](https://github.com/hosokawa-kenshin/Gcal.js/blob/main/README-ja.md)
 
 ## Requirements
+
 - Node.js
 - Google Calendar API must be enabled in the Google Cloud Console
 - `credentials.json` file must be obtained from the Google Cloud Console and placed in the program directory
   - For detailed setup instructions, see [Google Calendar API Credentials Setup Guide](./docs/oauth-en.md)
 
 ## Setup
+
 ### Install dependencies
 
 Run the following command in the project directory to install the necessary dependencies:
+
 ```bash
 npm install
 ```
@@ -58,12 +62,15 @@ npm install
 ### Create a symlink
 
 To command Gcal (cldr), create a symlink in a location where the path is accessible.
+
 ```bash
 export PATH=path/to/your/directory:$PATH
 cd your/directory
 ln -s path/to/Gcal.js/cldr cldr
 ```
+
 The following is a configuration example
+
 ```bash
 export PATH=$HOME/.local/bin:$PATH #(Permanent by adding it to .bashrc or .zshrc)
 cd ~/.local/bin
@@ -71,21 +78,25 @@ ln -s ~/git/Gcal.js/cldr cldr
 ```
 
 ## Usage
+
 ### Display
+
 When you start Gcal.js, three tables are displayed.  
 On the left are the events registered in Google Calendar, on the upper right is a graph showing the dates and times of events, and on the lower right is a log.  
 The event under the cursor is highlighted in blue.
 
 ### Basic operations
+
 Use the arrow keys or `jk` keys (like vim) to move the cursor.  
 Press the `q` key to exit the system.
 To select an event, place the cursor on the event you want to select and press the `Enter` key.
 Press the `Space` key to open the command line.
 
 ### Event add/edit/delete functions and available commands
-Please refer to the following for operation methods, specifications, and details of each:
-- [Add events](https://github.com/hosokawa-kenshin/Gcal.js/blob/main/docs/cmd/add.md) (Added information about how to add events using LLM on 2025/6/27)
 
+Please refer to the following for operation methods, specifications, and details of each:
+
+- [Add events](https://github.com/hosokawa-kenshin/Gcal.js/blob/main/docs/cmd/add.md)
 - [Edit events](https://github.com/hosokawa-kenshin/Gcal.js/blob/main/docs/cmd/edit.md)
 
 - [Delete events](https://github.com/hosokawa-kenshin/Gcal.js/blob/main/docs/cmd/delete.md)
@@ -120,6 +131,7 @@ Please refer to the following for operation methods, specifications, and details
 | `update`      | Update Gcal.js                                                                  |
 
 ## Shortcuts
+
 Some functions and commands have shortcuts.  
 You can also assign your own preferred keys.  
 The default key bindings are shown below.
@@ -138,6 +150,7 @@ The default key bindings are shown below.
 
 Set your key bindings:  
 Edit setting.json, key bindings can be changed.
+
 ```
 {
     "keyBindings": {
@@ -155,6 +168,7 @@ Edit setting.json, key bindings can be changed.
     }
 }
 ```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/setting.json.sample
+++ b/setting.json.sample
@@ -39,6 +39,9 @@
         ],
         "exitFullscreen": [
             "escape"
+        ],
+        "toggleLastYear": [
+            "y"
         ]
     }
 }

--- a/setting.json.sample
+++ b/setting.json.sample
@@ -42,6 +42,9 @@
         ],
         "toggleLastYear": [
             "y"
+        ],
+        "toggleCurrentDesc": [
+            "Y"
         ]
     }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import '../src/utils/datePrototype.js';
 import { createLayout, removeCommandPopup } from './ui/layout.js';
 import { handleInput } from './ui/inputHandler.js';
 import { authorize, initializeCalendars, initializeEvents } from './services/calendarService.js';
-import { editEvent } from './commands/edit.js';
+import { editEvent, copyEventToDate } from './commands/edit.js';
 import { hasUpdates, isForkedRepository } from './commands/update.js';
 import { loadSetting } from './services/settingService.js';
 import { setupKeyBindings } from './ui/keyConfig.js';
@@ -26,7 +26,7 @@ export async function runApp() {
   ];
   events.sort((a, b) => a.start - b.start);
 
-  const { screen, inputBox, keypressListener } = createLayout(calendars, events);
+  const { screen, inputBox, keypressListener, lastYearTable } = createLayout(calendars, events);
   const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
   const logTable = screen.children.find(child => child.options.label === 'Gcal.js Log');
 
@@ -62,6 +62,25 @@ export async function runApp() {
     const selectedEvent = selectedItem.event || null;
     const selectedDate = selectedItem.date || null;
     editEvent(auth, screen, calendars, selectedEvent, events, allEvents, selectedDate);
+  });
+
+  // 去年の予定テーブルから c キーでイベントをコピー
+  lastYearTable.key(['c'], () => {
+    const idx = lastYearTable.selected;
+    if (!lastYearTable.displayItems || !lastYearTable.displayItems[idx]) return;
+    const { event: lastYearEvent } = lastYearTable.displayItems[idx];
+    if (!lastYearEvent) {
+      logTable.log('コピーするイベントが選択されていません。');
+      screen.render();
+      return;
+    }
+
+    // 左テーブルの選択日を取得
+    const leftIdx = leftTable.selected;
+    const leftItem = leftTable.displayItems && leftTable.displayItems[leftIdx];
+    const targetDate = leftItem ? leftItem.date : new Date();
+
+    copyEventToDate(auth, screen, calendars, lastYearEvent, targetDate, events, allEvents);
   });
 
   setupKeyBindings(screen, auth, calendars, events, allEvents, inputBox, setting);

--- a/src/app.js
+++ b/src/app.js
@@ -105,6 +105,17 @@ export async function runApp() {
     copyEventToDate(auth, screen, calendars, lastYearEvent, targetDate, events, allEvents);
   });
 
+  // 右テーブルから Enter キーでイベント詳細・編集メニューを表示
+  lastYearTable.on('select', (item, index) => {
+    const selectedItem = lastYearTable.displayItems[index];
+    const selectedEvent = selectedItem.event || null;
+    const selectedDate = selectedItem.date || null;
+    const leftIdx = leftTable.selected;
+    const leftItem = leftTable.displayItems && leftTable.displayItems[leftIdx];
+    const copyTargetDate = leftItem ? leftItem.date : null;
+    editEvent(auth, screen, calendars, selectedEvent, events, allEvents, selectedDate, copyTargetDate);
+  });
+
   setupKeyBindings(screen, auth, calendars, events, allEvents, inputBox, setting);
 
   screen.render();

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import { editEvent, copyEventToDate } from './commands/edit.js';
 import { hasUpdates, isForkedRepository } from './commands/update.js';
 import { loadSetting } from './services/settingService.js';
 import { setupKeyBindings } from './ui/keyConfig.js';
+import { findInLastYear } from './commands/find.js';
 
 export async function runApp() {
   console.log('Running app ...');
@@ -30,6 +31,9 @@ export async function runApp() {
   const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
   const logTable = screen.children.find(child => child.options.label === 'Gcal.js Log');
 
+  // 去年パネル検索用のサブミットハンドラー（null = 通常の handleInput）
+  let lastYearSubmitHandler = null;
+
   if (updateAvailable) {
     logTable.log(
       '{blue-fg}Update available! Please run update command to update the app.{/blue-fg}'
@@ -40,19 +44,26 @@ export async function runApp() {
 
   inputBox.on('submit', value => {
     const inputValue = value;
+    const handler = lastYearSubmitHandler;
+    lastYearSubmitHandler = null;
 
     inputBox.clearValue();
     inputBox.hide();
 
     removeCommandPopup();
 
-    handleInput(auth, inputValue, screen, calendars, events, allEvents, keypressListener);
+    if (handler) {
+      handler(inputValue);
+    } else {
+      handleInput(auth, inputValue, screen, calendars, events, allEvents, keypressListener);
+    }
 
     screen.render();
   });
 
   inputBox.key(['escape'], () => {
     removeCommandPopup();
+    lastYearSubmitHandler = null;
     inputBox.hide();
     screen.render();
   });
@@ -62,6 +73,17 @@ export async function runApp() {
     const selectedEvent = selectedItem.event || null;
     const selectedDate = selectedItem.date || null;
     editEvent(auth, screen, calendars, selectedEvent, events, allEvents, selectedDate);
+  });
+
+  // 去年の予定テーブルから space キーで検索 inputBox を起動
+  lastYearTable.key(['space'], () => {
+    lastYearSubmitHandler = inputValue => {
+      findInLastYear(inputValue, allEvents, lastYearTable, logTable, screen);
+      lastYearTable.focus();
+    };
+    inputBox.show();
+    inputBox.focus();
+    screen.render();
   });
 
   // 去年の予定テーブルから c キーでイベントをコピー

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -233,7 +233,8 @@ export function editEvent(
   selectedEvent,
   events,
   allEvents,
-  selectedDate = null
+  selectedDate = null,
+  copyTargetDate = null
 ) {
   const calendar = google.calendar({ version: 'v3', auth });
   const calendarList = screen.children.find(child => child.options.label === 'Calendar List');
@@ -459,6 +460,12 @@ export function editEvent(
       case 2:
         promptCalendarSelection(async (selectedEditCalendar, selectedEditCalendarId) => {
           const initialValues = eventToFormValues(selectedEvent, fallbackDate);
+          if (copyTargetDate) {
+            const targetDateInfo = formatDate(copyTargetDate);
+            if (targetDateInfo?.date) {
+              initialValues.date = targetDateInfo.date;
+            }
+          }
 
           await prepareForm({
             label: `Edit Event - ${selectedEditCalendar}`,

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -618,3 +618,113 @@ export function editEvent(
     screen.render();
   });
 }
+
+/**
+ * 去年の予定テーブルから選択したイベントを targetDate の日付にコピーするフロー
+ * カレンダ選択 → フォーム（ソースイベントの内容を日付だけ targetDate に変更してプリフィル）→ 保存
+ */
+export async function copyEventToDate(
+  auth,
+  screen,
+  calendars,
+  sourceEvent,
+  targetDate,
+  events,
+  allEvents
+) {
+  const calendar = google.calendar({ version: 'v3', auth });
+  const calendarList = screen.children.find(child => child.options.label === 'Calendar List');
+  const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
+  const logTable = screen.children.find(child => child.options.label === 'Gcal.js Log');
+  const { formBox, formFields } = createAddForm(screen);
+  const tempFilePath = path.join(os.tmpdir(), 'blessed-editor.txt');
+
+  const calendarNames = Array.from(new Set(calendars.map(cal => cal.summary)));
+  const calendarIDs = Array.from(new Set(calendars.map(cal => cal.id)));
+
+  const showValidationError = () => {
+    logTable.log('Error: All fields must be filled in.');
+    screen.render();
+  };
+
+  const finalizeSuccess = async message => {
+    await updateTable(auth, leftTable, calendars, events, allEvents);
+    logTable.log(message);
+    if (!formBox.destroyed) {
+      formBox.destroy();
+    }
+    screen.render();
+    leftTable.focus();
+    screen.render();
+  };
+
+  const baseValues = eventToFormValues(sourceEvent);
+  const targetDateInfo = formatDate(targetDate);
+  const initialValues = {
+    ...baseValues,
+    date: targetDateInfo?.date || baseValues.date,
+  };
+
+  calendarList.show();
+  screen.render();
+  calendarList.focus();
+
+  calendarList.once('select', async (item, index) => {
+    const selectedCalendar = calendarNames[index];
+    const selectedCalendarId = calendarIDs[index];
+    calendarList.hide();
+    screen.render();
+
+    formBox.setLabel(
+      `Copy Event to ${targetDateInfo?.date || ''} - ${selectedCalendar}  (Ctrl+S to save)`
+    );
+    applyDetailsToForm(formFields, initialValues, {});
+    formBox.show();
+    formBox.focus();
+    screen.render();
+
+    setupEditorShortcut({ formBox, formFields, screen, tempFilePath, options: {} });
+
+    const updatedValues = await openEditorAndParse(screen, tempFilePath, initialValues, {});
+    if (updatedValues) {
+      applyDetailsToForm(formFields, updatedValues, {});
+      screen.render();
+    }
+
+    setupEscapeShortcut({ formBox, leftTable, logTable, screen });
+
+    setupSaveShortcut({
+      formBox,
+      formFields,
+      options: {},
+      handler: async values => {
+        if (!validateFormValues(values)) {
+          showValidationError();
+          return;
+        }
+
+        const eventResource = buildCalendarEventResource(values);
+
+        calendar.events.insert(
+          { calendarId: selectedCalendarId, resource: eventResource },
+          async err => {
+            if (err) {
+              console.error('The API returned an error: ' + err);
+              logTable.log('Error: Failed to register event.');
+              screen.render();
+              return;
+            }
+            await finalizeSuccess('Event successfully copied!');
+          }
+        );
+      },
+    });
+  });
+
+  calendarList.key(['escape'], () => {
+    calendarList.hide();
+    leftTable.focus();
+    screen.render();
+    logTable.log('Copy cancelled.');
+  });
+}

--- a/src/commands/find.js
+++ b/src/commands/find.js
@@ -2,23 +2,47 @@ import {
   createDisplayItemsForEvents,
   formatDisplayItems,
   searchDisplayItemIndex,
+  setLastYearSortOrder,
+  applyLastYearSort,
+  isRecentDescViewActive,
 } from '../ui/layout.js';
 import { isSameDate } from '../utils/dateUtils.js';
 
 /**
- * 去年の予定パネル専用の検索処理
- * "find <word>" または "f <word>" で前年のイベントをキーワードフィルタする
+ * 去年の予定パネル / Recent Events パネル専用の検索処理
+ * "find <word>" または "f <word>" でイベントをキーワードフィルタする
+ * "sort [asc|desc]" または "s [asc|desc]" でソート順を切り替える
  */
 export function findInLastYear(input, allEvents, lastYearTable, logTable, screen) {
   const [command, ...args] = input.trim().split(/\s+/);
-  if (command !== 'find' && command !== 'f') {
-    logTable.log('Last Year 検索: "find <keyword>" または "f <keyword>" で検索してください。');
+  const isRecent = isRecentDescViewActive();
+
+  // sort コマンドの処理
+  if (command === 'sort' || command === 's') {
+    const order = args[0]; // 'asc' | 'desc' | undefined
+    if (order && order !== 'asc' && order !== 'desc') {
+      logTable.log('並び替え: "sort asc" または "sort desc" を指定してください');
+      screen.render();
+      return;
+    }
+    setLastYearSortOrder(order);
+    applyLastYearSort(lastYearTable, screen);
+    const label = order ? `${order === 'asc' ? '昇順' : '降順'}` : 'トグル';
+    logTable.log(label === 'トグル' ? '並び順を切り替えました' : `${label}に並び替えました`);
     screen.render();
     return;
   }
 
-  const lastYearNum = new Date().getFullYear() - 1;
-  let filteredEvents = allEvents.filter(e => e.start.getFullYear() === lastYearNum);
+  if (command !== 'find' && command !== 'f') {
+    logTable.log('"find <keyword>" で検索，"sort [asc|desc]" で並び替えができます');
+    screen.render();
+    return;
+  }
+
+  // recentDesc モードでは全イベント、lastYear モードでは前年のみ対象
+  let filteredEvents = isRecent
+    ? [...allEvents]
+    : allEvents.filter(e => e.start.getFullYear() === new Date().getFullYear() - 1);
 
   if (args.length > 0) {
     filteredEvents = filteredEvents.filter(event =>
@@ -27,20 +51,17 @@ export function findInLastYear(input, allEvents, lastYearTable, logTable, screen
   }
 
   if (filteredEvents.length === 0) {
-    logTable.log(`Last Year: "${args.join(' ')}" に一致するイベントが見つかりませんでした。`);
+    logTable.log(`"${args.join(' ')}" に一致するイベントが見つかりませんでした`);
     screen.render();
     return;
   }
 
   const displayItems = createDisplayItemsForEvents(filteredEvents);
-  const formatted = formatDisplayItems(displayItems);
   lastYearTable.displayItems = displayItems;
-  lastYearTable.setItems(formatted);
-  lastYearTable.setLabel(`Last Year Events (${filteredEvents.length} results)`);
   lastYearTable.select(0);
   lastYearTable.scrollTo(0);
-  logTable.log(`Last Year: "${args.join(' ')}" で ${filteredEvents.length} 件に絞り込みました。`);
-  screen.render();
+  logTable.log(`"${args.join(' ')}" で ${filteredEvents.length} 件に絞り込みました`);
+  applyLastYearSort(lastYearTable, screen, `(${filteredEvents.length} results)`);
 }
 
 export function findCommand(screen, events, allEvents, args, keypressListener) {

--- a/src/commands/find.js
+++ b/src/commands/find.js
@@ -5,6 +5,44 @@ import {
 } from '../ui/layout.js';
 import { isSameDate } from '../utils/dateUtils.js';
 
+/**
+ * 去年の予定パネル専用の検索処理
+ * "find <word>" または "f <word>" で前年のイベントをキーワードフィルタする
+ */
+export function findInLastYear(input, allEvents, lastYearTable, logTable, screen) {
+  const [command, ...args] = input.trim().split(/\s+/);
+  if (command !== 'find' && command !== 'f') {
+    logTable.log('Last Year 検索: "find <keyword>" または "f <keyword>" で検索してください。');
+    screen.render();
+    return;
+  }
+
+  const lastYearNum = new Date().getFullYear() - 1;
+  let filteredEvents = allEvents.filter(e => e.start.getFullYear() === lastYearNum);
+
+  if (args.length > 0) {
+    filteredEvents = filteredEvents.filter(event =>
+      args.every(kw => event.summary && event.summary.includes(kw))
+    );
+  }
+
+  if (filteredEvents.length === 0) {
+    logTable.log(`Last Year: "${args.join(' ')}" に一致するイベントが見つかりませんでした。`);
+    screen.render();
+    return;
+  }
+
+  const displayItems = createDisplayItemsForEvents(filteredEvents);
+  const formatted = formatDisplayItems(displayItems);
+  lastYearTable.displayItems = displayItems;
+  lastYearTable.setItems(formatted);
+  lastYearTable.setLabel(`Last Year Events (${filteredEvents.length} results)`);
+  lastYearTable.select(0);
+  lastYearTable.scrollTo(0);
+  logTable.log(`Last Year: "${args.join(' ')}" で ${filteredEvents.length} 件に絞り込みました。`);
+  screen.render();
+}
+
 export function findCommand(screen, events, allEvents, args, keypressListener) {
   const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
   const logTable = screen.children.find(child => child.options.label === 'Gcal.js Log');

--- a/src/ui/keyConfig.js
+++ b/src/ui/keyConfig.js
@@ -57,6 +57,12 @@ export function setupKeyBindings(screen, auth, calendars, events, allEvents, inp
         jumpCommand(screen, events, allEvents, []));
 
     screen.key(keyBindings.toggleCommandLine || ['space'], () => {
+        // lastYearTable にフォーカスがある場合はトップレベルの space を無視
+        // blessed の list は内部の rows にフォーカスが当たるため親もチェック
+        const focused = screen.focused;
+        const focusedLabel = focused && focused.options && focused.options.label;
+        const parentLabel = focused && focused.parent && focused.parent.options && focused.parent.options.label;
+        if (focusedLabel === 'Last Year Events' || parentLabel === 'Last Year Events') return;
         inputBox.show();
         inputBox.focus();
         screen.render();
@@ -68,7 +74,7 @@ export function setupKeyBindings(screen, auth, calendars, events, allEvents, inp
     screen.key(keyBindings.exitFullscreen || ['escape'], () => toggleFullscreen(0));
 
     screen.key(keyBindings.toggleLastYear || ['y'], () =>
-        toggleLastYearView(screen, events));
+        toggleLastYearView(screen, events, allEvents));
 
     screen.key(['tab'], () => {
         const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');

--- a/src/ui/keyConfig.js
+++ b/src/ui/keyConfig.js
@@ -2,7 +2,7 @@ import { jumpCommand } from '../commands/jump.js';
 import { addEvent } from '../commands/add.js';
 import { addEventNL } from '../commands/addNL.js';
 import { editEvent } from '../commands/edit.js';
-import { toggleFullscreen } from './layout.js';
+import { toggleFullscreen, toggleLastYearView } from './layout.js';
 
 export function setupVimKeysForNavigation(widget, screen, focusbackwith) {
     screen.key(['j', 'k', 'h', 'l'], (ch, key) => {
@@ -66,6 +66,21 @@ export function setupKeyBindings(screen, auth, calendars, events, allEvents, inp
     screen.key(keyBindings.fullscreenTable2 || ['2'], () => toggleFullscreen(2));
     screen.key(keyBindings.fullscreenTable3 || ['3'], () => toggleFullscreen(3));
     screen.key(keyBindings.exitFullscreen || ['escape'], () => toggleFullscreen(0));
+
+    screen.key(keyBindings.toggleLastYear || ['y'], () =>
+        toggleLastYearView(screen, events));
+
+    screen.key(['tab'], () => {
+        const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
+        const lastYearTable = screen.children.find(child => child.options.label === 'Last Year Events');
+        if (!lastYearTable || lastYearTable.hidden) return;
+        if (screen.focused === leftTable) {
+            lastYearTable.focus();
+        } else {
+            leftTable.focus();
+        }
+        screen.render();
+    });
 }
 
 export function getDefaultKeyBindings() {
@@ -83,5 +98,6 @@ export function getDefaultKeyBindings() {
         fullscreenTable2: ['2'],
         fullscreenTable3: ['3'],
         exitFullscreen: ['escape'],
+        toggleLastYear: ['y'],
     };
 }

--- a/src/ui/keyConfig.js
+++ b/src/ui/keyConfig.js
@@ -2,7 +2,7 @@ import { jumpCommand } from '../commands/jump.js';
 import { addEvent } from '../commands/add.js';
 import { addEventNL } from '../commands/addNL.js';
 import { editEvent } from '../commands/edit.js';
-import { toggleFullscreen, toggleLastYearView } from './layout.js';
+import { toggleFullscreen, toggleLastYearView, toggleCurrentDescView } from './layout.js';
 
 export function setupVimKeysForNavigation(widget, screen, focusbackwith) {
     screen.key(['j', 'k', 'h', 'l'], (ch, key) => {
@@ -76,6 +76,9 @@ export function setupKeyBindings(screen, auth, calendars, events, allEvents, inp
     screen.key(keyBindings.toggleLastYear || ['y'], () =>
         toggleLastYearView(screen, events, allEvents));
 
+    screen.key(keyBindings.toggleCurrentDesc || ['Y', 'S-y'], () =>
+        toggleCurrentDescView(screen, events, allEvents));
+
     screen.key(['tab'], () => {
         const leftTable = screen.children.find(child => child.options.label === 'Upcoming Events');
         const lastYearTable = screen.children.find(child => child.options.label === 'Last Year Events');
@@ -105,5 +108,6 @@ export function getDefaultKeyBindings() {
         fullscreenTable3: ['3'],
         exitFullscreen: ['escape'],
         toggleLastYear: ['y'],
+        toggleCurrentDesc: ['Y'],
     };
 }

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -7,6 +7,7 @@ import { convertToDateTime, getDayOfWeek } from '../utils/dateUtils.js';
 import {
   createEventDetailTable,
   createEventTable,
+  createLastYearTable,
   createLeftTable,
   createLogTable,
 } from './table.js';
@@ -19,6 +20,7 @@ const { isHoliday } = pkg;
 let currentDisplayMode = 'split'; // 'split', 'fullscreen1', 'fullscreen2', 'fullscreen3'
 let originalLayouts = {}; // 各テーブルの元の位置・サイズ情報
 let tableReferences = {}; // テーブル参照を保持
+let lastYearViewActive = false; // 去年の予定ビュー表示状態
 
 /**
  * イベントを日付ごとに展開してMapに格納する共通処理
@@ -148,6 +150,60 @@ export function searchDisplayItemIndex(date, displayItems) {
 export function searchDisplayItemIndexOfToday(displayItems) {
   const today = new Date();
   return searchDisplayItemIndex(today, displayItems);
+}
+
+/**
+ * 去年の予定用 displayItems を生成する
+ * 現在の events から前年（today - 1年）を基準に createDisplayItems を呼び出す
+ */
+export function createLastYearDisplayItems(events) {
+  const today = new Date();
+  const lastYear = new Date(today.getFullYear() - 1, today.getMonth(), today.getDate());
+  return createDisplayItems(events, lastYear);
+}
+
+/**
+ * 去年の予定ビューと通常ビュー（グラフ+ログ）をトグルする
+ * @param {object} screen - blessed screen
+ * @param {Array} events - イベント配列
+ */
+export function toggleLastYearView(screen, events) {
+  const rightGraph = tableReferences.rightGraph;
+  const logTable = tableReferences.logTable;
+  const lastYearTable = tableReferences.lastYearTable;
+
+  if (!lastYearTable) return;
+
+  if (!lastYearViewActive) {
+    // Last Year ビューに切り替え
+    rightGraph.hide();
+    logTable.hide();
+    lastYearTable.show();
+    lastYearViewActive = true;
+
+    // 初回表示時に左テーブルの選択日と同期（-1年の日付に移動）
+    const leftTable = tableReferences.leftTable;
+    if (leftTable && leftTable.displayItems && lastYearTable.displayItems) {
+      const selectedItem = leftTable.displayItems[leftTable.selected];
+      if (selectedItem) {
+        const targetDate = new Date(selectedItem.date);
+        targetDate.setFullYear(targetDate.getFullYear() - 1);
+        const idx = searchDisplayItemIndex(targetDate, lastYearTable.displayItems);
+        lastYearTable.select(idx);
+        lastYearTable.scrollTo(idx + Math.floor(lastYearTable.height / 2));
+      }
+    }
+  } else {
+    // グラフ/ログビューに戻す
+    lastYearTable.hide();
+    rightGraph.show();
+    logTable.show();
+    lastYearViewActive = false;
+  }
+
+  if (screenInstance) {
+    screenInstance.render();
+  }
 }
 
 /**
@@ -439,6 +495,13 @@ export function recalculateDefaultLayouts() {
       height: '22%',
       hidden: false,
     },
+    lastYearTable: {
+      top: 0,
+      left: '50%',
+      width: '50%',
+      height: '100%',
+      hidden: true,
+    },
   };
 
   // originalLayoutsを新しいデフォルト値で更新
@@ -462,9 +525,11 @@ export function handleTerminalResize() {
         table.left = layout.left;
         table.width = layout.width;
         table.height = layout.height;
-        table.hidden = layout.hidden;
+        // hidden は lastYearViewActive の状態に従って設定する（layout.hidden は使わない）
       }
     });
+    // hidden 状態を現在のビューモードに合わせて再適用
+    showAllTables();
     if (screenInstance) {
       screenInstance.render();
     }
@@ -499,12 +564,22 @@ export function hideOtherTables(activeTableId) {
 
 export function showAllTables() {
   Object.keys(tableReferences).forEach(tableId => {
-    tableReferences[tableId].hidden = false;
+    // lastYearTable は lastYearViewActive のときのみ表示する
+    if (tableId === 'lastYearTable') {
+      tableReferences[tableId].hidden = !lastYearViewActive;
+    } else if (tableId === 'rightGraph' || tableId === 'logTable') {
+      tableReferences[tableId].hidden = lastYearViewActive;
+    } else {
+      tableReferences[tableId].hidden = false;
+    }
   });
 }
 
 export function toggleFullscreen(tableIndex) {
-  const tableIds = ['leftTable', 'rightGraph', 'logTable'];
+  // Last Year ビュー表示中は rightGraph の代わりに lastYearTable を tableIndex=2 として扱う
+  const tableIds = lastYearViewActive
+    ? ['leftTable', 'lastYearTable', 'logTable']
+    : ['leftTable', 'rightGraph', 'logTable'];
 
   // escapeキーの場合（tableIndex = 0）、3分割表示に戻る
   if (tableIndex === 0) {
@@ -841,6 +916,13 @@ export function createLayout(calendars, events) {
   updateGraph(screen, rightGraph, leftTable.selected, events, displayItems);
   const eventDetailTable = createEventDetailTable(screen);
 
+  // 去年の予定テーブルを生成・初期化
+  const lastYearTable = createLastYearTable(screen);
+  const lastYearDisplayItems = createLastYearDisplayItems(events);
+  const formattedLastYearEvents = formatDisplayItems(lastYearDisplayItems);
+  lastYearTable.displayItems = lastYearDisplayItems;
+  lastYearTable.setItems(formattedLastYearEvents);
+
   screen.append(inputBox);
   screen.append(list);
   screen.append(editCalendarCommandList);
@@ -852,19 +934,23 @@ export function createLayout(calendars, events) {
   setupVimKeysForNavigation(commandList, screen, null);
   setupVimKeysForNavigation(editCalendarCommandList, screen, null);
   setupVimKeysForNavigation(eventTable, screen, null);
+  setupVimKeysForNavigation(lastYearTable, screen, null);
 
   // テーブル参照の初期化と元のレイアウト情報の保存
   leftTable.tableId = 'leftTable';
   rightGraph.tableId = 'rightGraph';
   logTable.tableId = 'logTable';
+  lastYearTable.tableId = 'lastYearTable';
 
   tableReferences.leftTable = leftTable;
   tableReferences.rightGraph = rightGraph;
   tableReferences.logTable = logTable;
+  tableReferences.lastYearTable = lastYearTable;
 
   saveOriginalLayout(leftTable, 'leftTable');
   saveOriginalLayout(rightGraph, 'rightGraph');
   saveOriginalLayout(logTable, 'logTable');
+  saveOriginalLayout(lastYearTable, 'lastYearTable');
 
   leftTable.focus();
   leftTable.key(['space'], () => {
@@ -873,5 +959,5 @@ export function createLayout(calendars, events) {
     screen.render();
   });
   console.log('Create Layout');
-  return { screen, inputBox, keypressListener };
+  return { screen, inputBox, keypressListener, lastYearTable };
 }

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -165,9 +165,10 @@ export function createLastYearDisplayItems(events) {
 /**
  * 去年の予定ビューと通常ビュー（グラフ+ログ）をトグルする
  * @param {object} screen - blessed screen
- * @param {Array} events - イベント配列
+ * @param {Array} events - イベント配列（現在表示用）
+ * @param {Array} allEvents - 全イベント配列（去年パネルのリセットに使用）
  */
-export function toggleLastYearView(screen, events) {
+export function toggleLastYearView(screen, events, allEvents) {
   const rightGraph = tableReferences.rightGraph;
   const logTable = tableReferences.logTable;
   const lastYearTable = tableReferences.lastYearTable;
@@ -175,13 +176,20 @@ export function toggleLastYearView(screen, events) {
   if (!lastYearTable) return;
 
   if (!lastYearViewActive) {
-    // Last Year ビューに切り替え
+    // Last Year ビューに切り替え：allEvents を使って全去年イベントで再初期化（検索状態リセット）
+    const sourceEvents = allEvents || events;
+    const lastYearDisplayItems = createLastYearDisplayItems(sourceEvents);
+    const formattedLastYearEvents = formatDisplayItems(lastYearDisplayItems);
+    lastYearTable.displayItems = lastYearDisplayItems;
+    lastYearTable.setItems(formattedLastYearEvents);
+    lastYearTable.setLabel('Last Year Events');
+
     rightGraph.hide();
     logTable.hide();
     lastYearTable.show();
     lastYearViewActive = true;
 
-    // 初回表示時に左テーブルの選択日と同期（-1年の日付に移動）
+    // 左テーブルの選択日と同期（-1年の日付に移動）
     const leftTable = tableReferences.leftTable;
     if (leftTable && leftTable.displayItems && lastYearTable.displayItems) {
       const selectedItem = leftTable.displayItems[leftTable.selected];

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -21,6 +21,8 @@ let currentDisplayMode = 'split'; // 'split', 'fullscreen1', 'fullscreen2', 'ful
 let originalLayouts = {}; // 各テーブルの元の位置・サイズ情報
 let tableReferences = {}; // テーブル参照を保持
 let lastYearViewActive = false; // 去年の予定ビュー表示状態
+let lastYearSortOrder = 'asc'; // 去年の予定テーブルのソート順 ('asc' or 'desc')
+let recentDescViewActive = false; // 現在日時から降順ビュー表示状態
 
 /**
  * イベントを日付ごとに展開してMapに格納する共通処理
@@ -176,17 +178,23 @@ export function toggleLastYearView(screen, events, allEvents) {
   if (!lastYearTable) return;
 
   if (!lastYearViewActive) {
+    // recentDesc ビューが開いていれば先に閉じる
+    if (recentDescViewActive) {
+      recentDescViewActive = false;
+      lastYearSortOrder = 'asc';
+      lastYearTable.hide();
+    }
     // Last Year ビューに切り替え：allEvents を使って全去年イベントで再初期化（検索状態リセット）
     const sourceEvents = allEvents || events;
     const lastYearDisplayItems = createLastYearDisplayItems(sourceEvents);
-    const formattedLastYearEvents = formatDisplayItems(lastYearDisplayItems);
     lastYearTable.displayItems = lastYearDisplayItems;
-    lastYearTable.setItems(formattedLastYearEvents);
-    lastYearTable.setLabel('Last Year Events');
+    lastYearTable.setItems(formatDisplayItems(lastYearDisplayItems));
+    lastYearTable.setLabel('Last Year Events ↑');
 
     rightGraph.hide();
     logTable.hide();
     lastYearTable.show();
+    lastYearTable.focus();
     lastYearViewActive = true;
 
     // 左テーブルの選択日と同期（-1年の日付に移動）
@@ -207,11 +215,107 @@ export function toggleLastYearView(screen, events, allEvents) {
     rightGraph.show();
     logTable.show();
     lastYearViewActive = false;
+    lastYearSortOrder = 'asc';
   }
 
   if (screenInstance) {
     screenInstance.render();
   }
+}
+
+/**
+ * 現在日時から降順で全イベントを右パネルに表示するビューをトグルする
+ * @param {object} screen - blessed screen
+ * @param {Array} events - イベント配列
+ * @param {Array} allEvents - 全イベント配列
+ */
+export function toggleCurrentDescView(screen, events, allEvents) {
+  const rightGraph = tableReferences.rightGraph;
+  const logTable = tableReferences.logTable;
+  const lastYearTable = tableReferences.lastYearTable;
+
+  if (!lastYearTable) return;
+
+  if (!recentDescViewActive) {
+    // lastYear ビューが開いていれば先に閉じる
+    if (lastYearViewActive) {
+      lastYearViewActive = false;
+    }
+    lastYearSortOrder = 'desc';
+
+    // 全イベントを降順で表示（今日以前のイベントを最近順に）
+    const sourceEvents = allEvents || events;
+    const displayItems = createDisplayItemsForEvents(sourceEvents);
+    displayItems.sort((a, b) => b.date - a.date);
+    lastYearTable.displayItems = displayItems;
+    lastYearTable.setItems(formatDisplayItems(displayItems));
+    lastYearTable.setLabel('Recent Events ↓');
+
+    rightGraph.hide();
+    logTable.hide();
+    lastYearTable.show();
+    lastYearTable.focus();
+    recentDescViewActive = true;
+
+    // 今日の日付に近いアイテムにスクロール
+    const today = new Date();
+    const idx = displayItems.findIndex(item => item.date <= today);
+    const scrollIdx = idx >= 0 ? idx : 0;
+    lastYearTable.select(scrollIdx);
+    lastYearTable.scrollTo(scrollIdx + Math.floor(lastYearTable.height / 2));
+  } else {
+    // グラフ/ログビューに戻す
+    lastYearTable.hide();
+    rightGraph.show();
+    logTable.show();
+    recentDescViewActive = false;
+    lastYearSortOrder = 'asc';
+  }
+
+  if (screenInstance) {
+    screenInstance.render();
+  }
+}
+
+/**
+ * 現在日時から降順ビューがアクティブかどうかを返す
+ */
+export function isRecentDescViewActive() {
+  return recentDescViewActive;
+}
+
+/**
+ * 去年の予定テーブルのソート順を設定する
+ * @param {'asc'|'desc'|undefined} order - 'asc'/'desc' で固定，undefined でトグル
+ */
+export function setLastYearSortOrder(order) {
+  if (order === 'asc' || order === 'desc') {
+    lastYearSortOrder = order;
+  } else {
+    lastYearSortOrder = lastYearSortOrder === 'asc' ? 'desc' : 'asc';
+  }
+}
+
+/**
+ * 去年の予定テーブルのソートを適用して再描画する
+ * @param {object} lastYearTable - blessed list table
+ * @param {object} screen - blessed screen
+ * @param {string} [labelSuffix] - ラベルに追加するサフィックス（例: "(5 results)"）
+ */
+export function applyLastYearSort(lastYearTable, screen, labelSuffix) {
+  if (!lastYearTable || !lastYearTable.displayItems) return;
+
+  if (lastYearSortOrder === 'desc') {
+    lastYearTable.displayItems.sort((a, b) => b.date - a.date);
+  } else {
+    lastYearTable.displayItems.sort((a, b) => a.date - b.date);
+  }
+
+  const arrow = lastYearSortOrder === 'asc' ? '↑' : '↓';
+  const suffix = labelSuffix ? ` ${labelSuffix}` : '';
+  lastYearTable.setLabel(`Last Year Events ${arrow}${suffix}`);
+  lastYearTable.setItems(formatDisplayItems(lastYearTable.displayItems));
+  screen.render();
 }
 
 /**

--- a/src/ui/table.js
+++ b/src/ui/table.js
@@ -94,6 +94,30 @@ export function createEventTable(screen) {
   return eventTable;
 }
 
+export function createLastYearTable(screen) {
+  const lastYearTable = blessed.list({
+    hidden: true,
+    keys: true,
+    fg: 'white',
+    tags: true,
+    selectedFg: 'white',
+    selectedBg: 'blue',
+    interactive: true,
+    label: 'Last Year Events',
+    top: 0,
+    left: '50%',
+    width: '50%',
+    height: '100%',
+    border: { type: 'line', fg: 'yellow' },
+    columnSpacing: 2,
+    style: {
+      header: { bold: true },
+    },
+  });
+  screen.append(lastYearTable);
+  return lastYearTable;
+}
+
 export function createEventDetailTable(screen) {
   const eventDetailTable = blessed.list({
     hidden: true,


### PR DESCRIPTION
#### 去年の予定パネル / Recent Events パネル

右パネル（グラフ・ログ表示エリア）に，去年の同時期のイベントや全イベントを一覧表示する新しいビューを追加しました．

**キー操作**

| キー          | 動作                                                                                       |
| ------------- | ------------------------------------------------------------------------------------------ |
| `y`           | 去年の予定パネルをトグル（Last Year Events）                                               |
| `Y` (Shift+y) | 全イベントを最新順で表示するパネルをトグル（Recent Events ↓）                              |
| `Tab`         | 左パネル（Upcoming Events）と右パネル（Last Year / Recent Events）のフォーカスを切り替える |
| `c`           | 右パネルで選択中のイベントを，左パネルで選択中の日付にコピーする                           |
| `Enter`       | 右パネルで選択中のイベントの詳細・編集メニューを開く                                       |
| `Space`       | 右パネルにフォーカスがある場合，コマンド入力欄を開く（検索・ソートに使用）                 |

> `y` を押すと右パネルが切り替わり，左パネルで選択中の日付の1年前付近にスクロールします．

**右パネル専用コマンド（Space で入力欄を開いて使用）**

| コマンド                 | 短縮形             | 説明                                                            |
| ------------------------ | ------------------ | --------------------------------------------------------------- |
| `find <キーワード>`      | `f <キーワード>`   | キーワードでイベントを絞り込む（複数スペース区切りで AND 検索） |
| `sort asc` / `sort desc` | `s asc` / `s desc` | 昇順・降順に並び替える                                          |
| `sort`                   | `s`                | 昇順/降順をトグルする                                           |

#### イベントコピー機能

- 去年の予定パネルで `c` キーを押すと，選択イベントの内容（タイトル・時間など）を左パネルで選択中の日付に複製できます．
- カレンダー選択 → フォームに内容がプリフィルされた状態で編集 → `Ctrl+S` で保存するフローです．

#### 編集フォームへの日付引き継ぎ

- 右パネルから `Enter` でイベント編集メニューを開いた際，「編集」を選ぶと左パネルで選択中の日付がフォームの初期日付として設定されます（`copyTargetDate` の引き渡し）．

### 変更点

#### キーバインディング

`setting.json` に以下の2つのキーバインドを追加しました：

```json
"toggleLastYear": ["y"],
"toggleCurrentDesc": ["Y"]
```

`setting.json.sample` を更新済みです．既存の `setting.json` をお使いの場合は，上記を `keyBindings` セクションに追記してください．

#### Last Year Events パネルのフルスクリーン対応

- 去年の予定パネルが表示されている状態でも，`1`/`2`/`3` キーによるフルスクリーン切り替えが正しく動作するようになりました．
- `Escape` でフルスクリーン解除した際，去年の予定パネルの表示状態が正しく復元されます．

#### Space キーの挙動変更

- 右パネル（Last Year Events）にフォーカスがある状態で `Space` を押した場合，通常のコマンドライン（`handleInput`）ではなく，右パネル専用の検索・ソートコマンド入力フローが起動します．